### PR TITLE
This line throws an error

### DIFF
--- a/mode/javascript.js
+++ b/mode/javascript.js
@@ -228,7 +228,7 @@ function mkJavaScript(parserConfig) {
     var cc = state.cc;
     // Communicate our context to the combinators.
     // (Less wasteful than consing up a hundred closures on every call.)
-    cx.state = state; cx.stream = stream; cx.marked = null, cx.cc = cc; cx.style = style;
+    cx.state = state; cx.stream = stream; cx.marked = null; cx.cc = cc; cx.style = style;
 
     if (!state.lexical.hasOwnProperty("align"))
       state.lexical.align = true;


### PR DESCRIPTION
Not sure why the is `,` instead of `;`. This line was causing a compile error. Now it is working as expected.