### PR TITLE
Support for Structured Concurrency in Swift

### DIFF
--- a/mode/swift.js
+++ b/mode/swift.js
@@ -4,14 +4,14 @@ function wordSet(words) {
   return set
 }
 
-var keywords = wordSet(["_","var","let","class","enum","extension","import","protocol","struct","func","typealias","associatedtype",
+var keywords = wordSet(["_","var","let","actor","class","enum","extension","import","protocol","struct","func","typealias","associatedtype",
                         "open","public","internal","fileprivate","private","deinit","init","new","override","self","subscript","super",
                         "convenience","dynamic","final","indirect","lazy","required","static","unowned","unowned(safe)","unowned(unsafe)","weak","as","is",
                         "break","case","continue","default","else","fallthrough","for","guard","if","in","repeat","switch","where","while",
-                        "defer","return","inout","mutating","nonmutating","catch","do","rethrows","throw","throws","try","didSet","get","set","willSet",
+                        "defer","return","inout","mutating","nonmutating","isolated","nonisolated","catch","do","rethrows","throw","throws","async","await","try","didSet","get","set","willSet",
                         "assignment","associativity","infix","left","none","operator","postfix","precedence","precedencegroup","prefix","right",
                         "Any","AnyObject","Type","dynamicType","Self","Protocol","__COLUMN__","__FILE__","__FUNCTION__","__LINE__"])
-var definingKeywords = wordSet(["var","let","class","enum","extension","import","protocol","struct","func","typealias","associatedtype","for"])
+var definingKeywords = wordSet(["var","let","actor","class","enum","extension","import","protocol","struct","func","typealias","associatedtype","for"])
 var atoms = wordSet(["true","false","nil","self","super","_"])
 var types = wordSet(["Array","Bool","Character","Dictionary","Double","Float","Int","Int8","Int16","Int32","Int64","Never","Optional","Set","String",
                      "UInt8","UInt16","UInt32","UInt64","Void"])


### PR DESCRIPTION
* Added `actor`, `isolated`, `nonisolated`, `async`, and `await` to `keywords`
* Added `actor` to `definingKeywords`