### PR TITLE
Add type declarations for simple-mode

### DIFF
--- a/mode/simple-mode.d.ts
+++ b/mode/simple-mode.d.ts
@@ -1,0 +1,13 @@
+import {StreamParser} from "@codemirror/language"
+export interface Rule {
+  regex?: string | RegExp | undefined;
+  token?: string | string[] | null | undefined | ((RegExpMatchArray) => string | string[] | null);
+  sol?: boolean | undefined;
+  next?: string | undefined;
+  push?: string | undefined;
+  pop?: boolean | undefined;
+  indent?: boolean | undefined;
+  dedent?: boolean | undefined;
+  dedentIfLineStart?: boolean | undefined;
+}
+export declare function simpleMode<K extends string>(states: { [P in K]: P extends "languageData" ? {[name: string]: any} : Rule[] } & { start: Rule[] }): StreamParser<unknown>


### PR DESCRIPTION
Those are based on the type definitions in wrote for codemirror5 in DefinitelyTyped, omitting the `mode` property of the rule that does not exist anymore, and changing `meta` to `languageData`.

The weird generic on `simpleMode<K extends string>()` is because typescript does not allow defining a different type for `languageData` when using `P in string` instead of a generic (that will be inferred as the the union of state names instead of the full `string` type)