### PR TITLE
Add Farsi characters to command detection

### DIFF
--- a/mode/stex.js
+++ b/mode/stex.js
@@ -81,7 +81,7 @@ function mkStex(mathMode) {
   function normal(source, state) {
     var plug;
     // Do we look like '\command' ?  If so, attempt to apply the plugin 'command'
-    if (source.match(/^\\[a-zA-Z@]+/)) {
+    if (source.match(/^\\[a-zA-Z@\u0622\u0627\u0628\u067E\u062A-\u062C\u0686\u062D-\u0632\u0698\u0633-\u063A\u0641\u0642\u06A9\u06AF\u0644-\u0648\u06CC]+/)) {
       var cmdName = source.current().slice(1);
       plug = plugins.hasOwnProperty(cmdName) ? plugins[cmdName] : plugins["DEFAULT"];
       plug = new plug();


### PR DESCRIPTION
In addition to Latin characters, packages like xetex enable users to have commands defined by e.g., Farsi characters. This pull request adds such characters to the list of characters that can form a command. This list requires extending to include all Arabic and maybe other language characters.