### PR TITLE
pegjs.js: fix .js import for Webpack 5

### DIFF
--- a/mode/pegjs.js
+++ b/mode/pegjs.js
@@ -1,4 +1,4 @@
-import {javascript} from "./javascript"
+import {javascript} from "./javascript.js"
 
 function identifier(stream) {
   return stream.match(/^[a-zA-Z_][a-zA-Z0-9_]*/)


### PR DESCRIPTION
Same error as in https://github.com/codemirror/dev/issues/522.

Same solution as in commit 2d69f0ecba9d22c3c1872f676c392b09db9f3755