### PR TITLE
Fix shell heredoc token

### DIFF
--- a/mode/shell.js
+++ b/mode/shell.js
@@ -55,9 +55,9 @@ function tokenBase(stream, state) {
   }
   if (ch == "<") {
     if (stream.match("<<")) return "operator"
-    var heredoc = stream.match(/^<-?\s*['"]?([^'"]*)['"]?/)
+    var heredoc = stream.match(/^<-?\s*(?:['"]([^'"]*)['"]|([^'"\s]*))/)
     if (heredoc) {
-      state.tokens.unshift(tokenHeredoc(heredoc[1]))
+      state.tokens.unshift(tokenHeredoc(heredoc[1] || heredoc[2]))
       return 'string.special'
     }
   }


### PR DESCRIPTION
A heredoc token cannot contains whitespaces. If we don't add this rule, we will have a wrong coloration when the heredoc is, for example, piped into a second command.

```
cat << EOF |
foo
EOF
bar
```

on the main branch, `bar` will be colorized like the heredoc. With the correction, it will have the correct color. 

The correction is not perfect as the pipe shouldn't be colorized like the heredoc, but it's a first step.