### PR TITLE
Add types to `exports` field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "url": "http://marijnhaverbeke.nl"
   },
   "type": "module",
-  "types": "dist/index.d.ts",
   "module": "dist/index.js",
   "exports": {
     "./mode/*": {
+      "types": "./mode/*.d.ts",
       "import": "./mode/*.js",
       "require": "./mode/*.cjs"
     },


### PR DESCRIPTION
I could not manage to get this package working with `Node16` module resolution in TypeScript, because apparently it "can't find the corresponding type definitions for ...". This PR should fix those issues.