### PR TITLE
commonlisp: recognize [ as opening bracket

### DIFF
--- a/mode/commonlisp.js
+++ b/mode/commonlisp.js
@@ -20,8 +20,8 @@ function base(stream, state) {
   if (ch == "\\") ch = stream.next();
 
   if (ch == '"') return (state.tokenize = inString)(stream, state);
-  else if (ch == "(" || ch == "[") { type = "open"; return "bracket"; }
-  else if (ch == ")" || ch == "]") { type = "close"; return "bracket"; }
+  else if (ch == "(") { type = "open"; return "bracket"; }
+  else if (ch == ")") { type = "close"; return "bracket"; }
   else if (ch == ";") { stream.skipToEnd(); type = "ws"; return "comment"; }
   else if (/['`,@]/.test(ch)) return null;
   else if (ch == "|") {

--- a/mode/commonlisp.js
+++ b/mode/commonlisp.js
@@ -20,7 +20,7 @@ function base(stream, state) {
   if (ch == "\\") ch = stream.next();
 
   if (ch == '"') return (state.tokenize = inString)(stream, state);
-  else if (ch == "(") { type = "open"; return "bracket"; }
+  else if (ch == "(" || ch == "[") { type = "open"; return "bracket"; }
   else if (ch == ")" || ch == "]") { type = "close"; return "bracket"; }
   else if (ch == ";") { stream.skipToEnd(); type = "ws"; return "comment"; }
   else if (/['`,@]/.test(ch)) return null;


### PR DESCRIPTION
when ] appears in atoms, it's wrongly matched with (

in this sample
```
(x y z[1-3])
```
the ( is matched with ] because [ is disregarded