### PR TITLE
Fix "is undefined" typo

### DIFF
--- a/mode/simple-mode.js
+++ b/mode/simple-mode.js
@@ -110,7 +110,7 @@ function tokenFunction(states) {
 
 function indentFunction(states, meta) {
   return function(state, textAfter) {
-    if (state.indent == null || meta.dontIndentStates && meta.doneIndentState.indexOf(state.state) > -1)
+    if (state.indent == null || meta.dontIndentStates && meta.dontIndentState.indexOf(state.state) > -1)
       return null
 
     var pos = state.indent.length - 1, rules = states[state.state];


### PR DESCRIPTION
Fix the `TypeError: g.doneIndentState is undefined` errors when doing multiple new lines on spadelangs playground.
I **think** this is a typo, because I can't find any naming of doneIdentState elsewhere, and comparing to the non-legacy indent function this seems correct, but correct me if I'm wrong :D