### PR TITLE
q: add comment string + fix block comment regex

### DIFF
--- a/mode/q.js
+++ b/mode/q.js
@@ -45,7 +45,7 @@ function tokenBase(stream,state){
   return"error";
 }
 function tokenLineComment(stream,state){
-  return stream.skipToEnd(),/\/\s*$/.test(stream.current())?(state.tokenize=tokenBlockComment)(stream,state):(state.tokenize=tokenBase),"comment";
+  return stream.skipToEnd(),/^\/\s*$/.test(stream.current())?(state.tokenize=tokenBlockComment)(stream,state):(state.tokenize=tokenBase),"comment";
 }
 function tokenBlockComment(stream,state){
   var f=stream.sol()&&stream.peek()=="\\";
@@ -117,5 +117,8 @@ export const q = {
       return context.col+(closing?0:1);
     else
       return context.indent+(closing?0:cx.unit);
-  }
+  },
+  languageData: {
+    commentTokens: { line: "/" },
+  },
 };


### PR DESCRIPTION
- adds q's line comment char of `/`
- corrects q's block comment syntax

```q
/
this is commented
\
//
This is not commented, but codemirror highlights it as if it were
\
```

And how about that, github-linguist uses a parser that highlights it correctly.

I've tested both changes by building jupyter lab with this patch applied. Let me know if there's anything else I need to do