### PR TITLE
Fix simple-mode unicode regex flag being dropped

### DIFF
--- a/mode/simple-mode.js
+++ b/mode/simple-mode.js
@@ -37,6 +37,7 @@ function toRegex(val, caret) {
   var flags = "";
   if (val instanceof RegExp) {
     if (val.ignoreCase) flags = "i";
+    if (val.unicode) flags += "u";
     val = val.source;
   } else {
     val = String(val);


### PR DESCRIPTION
Same as this patch from cm5 https://github.com/codemirror/codemirror5/commit/dc3952a60b6cf8ea7b2cb66521ae5165a04d444e